### PR TITLE
Edit to npm installation of tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ and then run the following command, with the package manager you'd like to use.
 #### npm
 
 ```sh
-npm install tailwindcss
+npm install tailwindcss @tailwindcss/cli 
 ```
 
 #### pnpm


### PR DESCRIPTION
Changed "npm install tailwindcss" to "npm install tailwindcss @tailwindcss/cli" based on recent documentation